### PR TITLE
Fix Hidpi MacOs

### DIFF
--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -31,6 +31,7 @@ GLFWGameWindow::GLFWGameWindow(const std::string& title, int width, int height, 
     glfwSetKeyCallback(window, _glfwKeyCallback);
     glfwSetCharCallback(window, _glfwCharCallback);
     glfwSetWindowFocusCallback(window, _glfwWindowFocusCallback);
+    glfwSetWindowContentScaleCallback(window, _glfwWindowContentScaleCallback);
     glfwMakeContextCurrent(window);
 
     setRelativeScale();
@@ -265,4 +266,9 @@ void GLFWGameWindow::_glfwWindowFocusCallback(GLFWwindow* window, int focused) {
     GLFWGameWindow* user = (GLFWGameWindow*) glfwGetWindowUserPointer(window);
     GLFWJoystickManager::onWindowFocused(user, focused == GLFW_TRUE);
     user->focused = (focused == GLFW_TRUE);
+}
+
+void GLFWGameWindow::_glfwWindowContentScaleCallback(GLFWwindow* window, float scalex, float scaley) {
+    GLFWGameWindow* user = (GLFWGameWindow*) glfwGetWindowUserPointer(window);
+    user->setRelativeScale();
 }

--- a/src/window_glfw.h
+++ b/src/window_glfw.h
@@ -25,6 +25,7 @@ private:
     static void _glfwCharCallback(GLFWwindow* window, unsigned int ch);
     static void _glfwWindowCloseCallback(GLFWwindow* window);
     static void _glfwWindowFocusCallback(GLFWwindow* window, int focused);
+    static void _glfwWindowContentScaleCallback(GLFWwindow* window, float scalex, float scaley);
 
 public:
 


### PR DESCRIPTION
Fix: mouse input if someone drag Minecraft from one Monitor to another,
with different backbuffer scaling factor
Fix: content scaling and mouse input if using angle on MacOs