### PR TITLE
Request OpenGL ES 3.0 on macOS

### DIFF
--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -14,7 +14,11 @@ GLFWGameWindow::GLFWGameWindow(const std::string& title, int width, int height, 
     if (api == GraphicsApi::OPENGL_ES2) {
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+        #ifdef __APPLE__
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+        #else
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+        #endif
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
     } else if (api == GraphicsApi::OPENGL) {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);


### PR DESCRIPTION
This allows the Metal backend of angle to work much better.