### PR TITLE
x11sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+on: pull_request
+name: ci
+jobs:
+ linux:
+    uses: ChristopherHX/linux-packaging-scripts/.github/workflows/main.yml@main
+    with:
+      submodule-refs: |-
+        [
+          {
+            "project": "mcpelauncher",
+            "path": "game-window",
+            "ref": ${{ tojson(github.sha) }}
+          }
+        ]
+ macOS:
+    uses: ChristopherHX/osx-packaging-scripts/.github/workflows/main.yml@main
+    with:
+      submodule-refs: |-
+        [
+          {
+            "project": "mcpelauncher",
+            "path": "game-window",
+            "ref": ${{ tojson(github.sha) }}
+          }
+        ]

--- a/src/window_eglut.cpp
+++ b/src/window_eglut.cpp
@@ -15,7 +15,9 @@ EGLUTWindow* EGLUTWindow::currentWindow;
 EGLUTWindow::EGLUTWindow(const std::string& title, int width, int height, GraphicsApi api) :
         WindowWithLinuxJoystick(title, width, height, api), title(title), width(width), height(height),
         graphicsApi(api) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutInitWindowSize(width, height);
     if (graphicsApi == GraphicsApi::OPENGL_ES2)
         eglutInitAPIMask(EGLUT_OPENGL_ES2_BIT);
@@ -40,7 +42,9 @@ EGLUTWindow::EGLUTWindow(const std::string& title, int width, int height, Graphi
 }
 
 EGLUTWindow::~EGLUTWindow() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     if (currentWindow == this)
         currentWindow = nullptr;
     if (winId != -1)
@@ -48,53 +52,71 @@ EGLUTWindow::~EGLUTWindow() {
 }
 
 void EGLUTWindow::setIcon(std::string const &iconPath) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutSetWindowIcon(iconPath.c_str());
 }
 
 void EGLUTWindow::makeCurrent(bool active) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutMakeCurrent(active ? winId : -1);
 }
 
 void EGLUTWindow::show() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutShowWindow();
     currentWindow = this;
     addWindowToGamepadManager();
 }
 
 void EGLUTWindow::close() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutDestroyWindow(currentWindow->winId);
     eglutFini();
     currentWindow->winId = -1;
 }
 
 void EGLUTWindow::pollEvents() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutPollEvents();
 }
 
 void EGLUTWindow::setCursorDisabled(bool disabled) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     cursorDisabled = disabled;
     eglutSetMousePointerLocked(disabled ? EGLUT_POINTER_LOCKED : EGLUT_POINTER_UNLOCKED);
 }
 
 void EGLUTWindow::setFullscreen(bool fullscreen) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     if (eglutGet(EGLUT_FULLSCREEN_MODE) != (fullscreen ? EGLUT_FULLSCREEN : EGLUT_WINDOWED))
         eglutToggleFullscreen();
 }
 
 void EGLUTWindow::swapBuffers() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutSwapBuffers();
 }
 
 void EGLUTWindow::setSwapInterval(int interval) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutSwapInterval(interval);
 }
 
@@ -323,6 +345,8 @@ void EGLUTWindow::getWindowSize(int& width, int& height) const {
 }
 
 void EGLUTWindow::setClipboardText(std::string const &text) {    
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     eglutSetClipboardText(text.c_str());
 }

--- a/src/window_eglut.h
+++ b/src/window_eglut.h
@@ -2,6 +2,8 @@
 
 #include "window_with_linux_gamepad.h"
 
+#include <mutex>
+
 class EGLUTWindow : public WindowWithLinuxJoystick {
 
 private:
@@ -16,6 +18,8 @@ private:
     int lastMouseX = -1, lastMouseY = -1;
     bool modCTRL = false;
     int pointerIds[16];
+
+    std::recursive_mutex x11_sync;
 
     static KeyCode getKeyMinecraft(int keyCode);
 

--- a/src/window_eglut.h
+++ b/src/window_eglut.h
@@ -1,4 +1,7 @@
 #pragma once
+#if !defined(GAMEWINDOW_NO_X11_LOCK) && !defined(GAMEWINDOW_X11_LOCK) && !defined(__APPLE__)
+#define GAMEWINDOW_X11_LOCK
+#endif
 
 #include "window_with_linux_gamepad.h"
 
@@ -19,7 +22,9 @@ private:
     bool modCTRL = false;
     int pointerIds[16];
 
+#ifdef GAMEWINDOW_X11_LOCK
     std::recursive_mutex x11_sync;
+#endif
 
     static KeyCode getKeyMinecraft(int keyCode);
 

--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -10,7 +10,9 @@
 
 GLFWGameWindow::GLFWGameWindow(const std::string& title, int width, int height, GraphicsApi api) :
         GameWindow(title, width, height, api), windowedWidth(width), windowedHeight(height) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwDefaultWindowHints();
     if (api == GraphicsApi::OPENGL_ES2) {
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
@@ -50,12 +52,16 @@ GLFWGameWindow::GLFWGameWindow(const std::string& title, int width, int height, 
 }
 
 void GLFWGameWindow::makeCurrent(bool c) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwMakeContextCurrent(c ? window : nullptr);
 }
 
 GLFWGameWindow::~GLFWGameWindow() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     GLFWJoystickManager::removeWindow(this);
     glfwDestroyWindow(window);
 }
@@ -65,7 +71,9 @@ void GLFWGameWindow::setIcon(std::string const& iconPath) {
 }
 
 void GLFWGameWindow::setRelativeScale() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     int fx, fy;
     glfwGetFramebufferSize(window, &fx, &fy);
 
@@ -80,23 +88,31 @@ int GLFWGameWindow::getRelativeScale() const {
 }
 
 void GLFWGameWindow::getWindowSize(int& width, int& height) const {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwGetFramebufferSize(window, &width, &height);
 }
 
 void GLFWGameWindow::show() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     GLFWJoystickManager::addWindow(this);
     glfwShowWindow(window);
 }
 
 void GLFWGameWindow::close() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwSetWindowShouldClose(window, GLFW_TRUE);
 }
 
 void GLFWGameWindow::pollEvents() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     resized = false;
     glfwPollEvents();
     if(resized)
@@ -105,13 +121,17 @@ void GLFWGameWindow::pollEvents() {
 }
 
 void GLFWGameWindow::setCursorDisabled(bool disabled) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwSetInputMode(window, GLFW_CURSOR, disabled ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
     glfwGetCursorPos(window, &lastMouseX, &lastMouseY);
 }
 
 void GLFWGameWindow::setFullscreen(bool fullscreen) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     if (fullscreen) {
         glfwGetWindowPos(window, &windowedX, &windowedY);
         glfwGetFramebufferSize(window, &windowedWidth, &windowedHeight);
@@ -124,17 +144,23 @@ void GLFWGameWindow::setFullscreen(bool fullscreen) {
 }
 
 void GLFWGameWindow::setClipboardText(std::string const &text) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwSetClipboardString(window, text.c_str());
 }
 
 void GLFWGameWindow::swapBuffers() {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwSwapBuffers(window);
 }
 
 void GLFWGameWindow::setSwapInterval(int interval) {
-    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#ifdef GAMEWINDOW_X11_LOCK
+    std::lock_guard<std::recursive_mutex> lock(x11_sync);
+#endif
     glfwSwapInterval(interval);
 }
 

--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -10,6 +10,7 @@
 
 GLFWGameWindow::GLFWGameWindow(const std::string& title, int width, int height, GraphicsApi api) :
         GameWindow(title, width, height, api), windowedWidth(width), windowedHeight(height) {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwDefaultWindowHints();
     if (api == GraphicsApi::OPENGL_ES2) {
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
@@ -49,10 +50,12 @@ GLFWGameWindow::GLFWGameWindow(const std::string& title, int width, int height, 
 }
 
 void GLFWGameWindow::makeCurrent(bool c) {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwMakeContextCurrent(c ? window : nullptr);
 }
 
 GLFWGameWindow::~GLFWGameWindow() {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     GLFWJoystickManager::removeWindow(this);
     glfwDestroyWindow(window);
 }
@@ -62,6 +65,7 @@ void GLFWGameWindow::setIcon(std::string const& iconPath) {
 }
 
 void GLFWGameWindow::setRelativeScale() {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     int fx, fy;
     glfwGetFramebufferSize(window, &fx, &fy);
 
@@ -76,19 +80,23 @@ int GLFWGameWindow::getRelativeScale() const {
 }
 
 void GLFWGameWindow::getWindowSize(int& width, int& height) const {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwGetFramebufferSize(window, &width, &height);
 }
 
 void GLFWGameWindow::show() {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     GLFWJoystickManager::addWindow(this);
     glfwShowWindow(window);
 }
 
 void GLFWGameWindow::close() {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwSetWindowShouldClose(window, GLFW_TRUE);
 }
 
 void GLFWGameWindow::pollEvents() {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     resized = false;
     glfwPollEvents();
     if(resized)
@@ -97,11 +105,13 @@ void GLFWGameWindow::pollEvents() {
 }
 
 void GLFWGameWindow::setCursorDisabled(bool disabled) {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwSetInputMode(window, GLFW_CURSOR, disabled ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
     glfwGetCursorPos(window, &lastMouseX, &lastMouseY);
 }
 
 void GLFWGameWindow::setFullscreen(bool fullscreen) {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     if (fullscreen) {
         glfwGetWindowPos(window, &windowedX, &windowedY);
         glfwGetFramebufferSize(window, &windowedWidth, &windowedHeight);
@@ -114,14 +124,17 @@ void GLFWGameWindow::setFullscreen(bool fullscreen) {
 }
 
 void GLFWGameWindow::setClipboardText(std::string const &text) {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwSetClipboardString(window, text.c_str());
 }
 
 void GLFWGameWindow::swapBuffers() {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwSwapBuffers(window);
 }
 
 void GLFWGameWindow::setSwapInterval(int interval) {
+    const std::lock_guard<std::recursive_mutex> lock(x11_sync);
     glfwSwapInterval(interval);
 }
 

--- a/src/window_glfw.h
+++ b/src/window_glfw.h
@@ -2,6 +2,7 @@
 
 #include <game_window.h>
 #include <GLFW/glfw3.h>
+#include <mutex>
 
 class GLFWGameWindow : public GameWindow {
 
@@ -16,6 +17,8 @@ private:
     bool warnedButtons = false;
 
     friend class GLFWJoystickManager;
+
+    std::recursive_mutex x11_sync;
 
     static KeyCode getKeyMinecraft(int keyCode);
 

--- a/src/window_glfw.h
+++ b/src/window_glfw.h
@@ -1,4 +1,7 @@
 #pragma once
+#if !defined(GAMEWINDOW_NO_X11_LOCK) && !defined(GAMEWINDOW_X11_LOCK) && !defined(__APPLE__)
+#define GAMEWINDOW_X11_LOCK
+#endif
 
 #include <game_window.h>
 #include <GLFW/glfw3.h>
@@ -18,7 +21,9 @@ private:
 
     friend class GLFWJoystickManager;
 
+#ifdef GAMEWINDOW_X11_LOCK
     std::recursive_mutex x11_sync;
+#endif
 
     static KeyCode getKeyMinecraft(int keyCode);
 


### PR DESCRIPTION
The x11 client library is **not** thread safe by default, starting with ubuntu 22.10 this becomes a problem and we see asserts after playing an extended period of time.

This change forces that event polling and buffer are not swapped concurrently. This change is disabled on macOS by default.