### PR TITLE
Fix fullscreen via symbol on macOS

### DIFF
--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -151,6 +151,7 @@ void GLFWGameWindow::setFullscreen(bool fullscreen) {
     } else {
         glfwSetWindowMonitor(window, nullptr, windowedX, windowedY, oldWindowedWidth / getRelativeScale(), oldWindowedHeight / getRelativeScale(), GLFW_DONT_CARE);
     }
+    onWindowSizeChanged(windowedWidth, windowedHeight);
 }
 
 void GLFWGameWindow::setClipboardText(std::string const &text) {


### PR DESCRIPTION
Window size is now updated correctly when using the new fullscreen handling on macOS