### PR TITLE
fullscreen fixes macOS retina

### DIFF
--- a/include/game_window.h
+++ b/include/game_window.h
@@ -79,6 +79,7 @@ public:
 
     virtual void setFullscreen(bool fullscreen) = 0;
 
+    // width and height in content pixels
     virtual void getWindowSize(int& width, int& height) const = 0;
 
     virtual void setClipboardText(std::string const& text) = 0;

--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -96,8 +96,8 @@ int GLFWGameWindow::getRelativeScale() const {
 }
 
 void GLFWGameWindow::getWindowSize(int& width, int& height) const {
-    width = width;
-    height = height;
+    width = this->width;
+    height = this->height;
 }
 
 void GLFWGameWindow::show() {

--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -9,7 +9,7 @@
 #include <math.h>
 
 GLFWGameWindow::GLFWGameWindow(const std::string& title, int width, int height, GraphicsApi api) :
-        GameWindow(title, width, height, api), width(width), height(height) {
+        GameWindow(title, width, height, api), width(width), height(height), windowedWidth(width), windowedHeight(height) {
 #ifdef GAMEWINDOW_X11_LOCK
     std::lock_guard<std::recursive_mutex> lock(x11_sync);
 #endif

--- a/src/window_glfw.h
+++ b/src/window_glfw.h
@@ -13,7 +13,10 @@ private:
     GLFWwindow* window;
     double lastMouseX = 0.0, lastMouseY = 0.0;
     int windowedX = -1, windowedY = -1;
-    int windowedWidth = -1, windowedHeight = -1, oldWindowedWidth = -1, oldWindowedHeight = -1;
+    // width and height in content pixels
+    int width = -1, height = -1
+    // width and height in window coordinates = pixels / relativeScale
+    int windowedWidth = -1, windowedHeight = -1;
     int relativeScale;
     bool resized = false;
     bool focused = true;

--- a/src/window_glfw.h
+++ b/src/window_glfw.h
@@ -14,7 +14,7 @@ private:
     double lastMouseX = 0.0, lastMouseY = 0.0;
     int windowedX = -1, windowedY = -1;
     // width and height in content pixels
-    int width = -1, height = -1
+    int width = -1, height = -1;
     // width and height in window coordinates = pixels / relativeScale
     int windowedWidth = -1, windowedHeight = -1;
     int relativeScale;


### PR DESCRIPTION
This fixes issues with the windowedsize before entering fullscreen.

For example if the window scale is in windowed mode 2, during restoring it might be 1 due to fullscreen mode changing the resolution.