### PR TITLE
Fix sigsegv when ctrl-v with non-text data

### DIFF
--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -338,7 +338,9 @@ void GLFWGameWindow::_glfwKeyCallback(GLFWwindow* window, int key, int scancode,
 #else
     if (action == GLFW_PRESS && mods & GLFW_MOD_CONTROL && key == GLFW_KEY_V) {
 #endif
-        user->onPaste(glfwGetClipboardString(window));
+        auto clipboardString = glfwGetClipboardString(window);
+        if(clipboardString != nullptr)
+            user->onPaste(clipboardString);
     }
     if (action == GLFW_PRESS || action == GLFW_REPEAT) {
         if (key == GLFW_KEY_BACKSPACE)


### PR DESCRIPTION
glfwGetClipboardString returns NULL if non-text data, such as images, is in the clipboard.