### PR TITLE
GLFW: Fix Relative Scale to account for Fractional Scaling on Wayland compositors

### DIFF
--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -88,14 +88,14 @@ void GLFWGameWindow::setRelativeScale() {
     int wx, wy;
     glfwGetWindowSize(window, &wx, &wy);
 
-    relativeScale = (int) floor(((fx / wx) + (fy / wy)) / 2);
+    relativeScale = (((double) fx / (double) wx) + ((double) fy / (double) wy)) / 2.0;
     // Update window size to match content size mismatch
     width = fx;
     height = fy;
     resized = true;
 }
 
-int GLFWGameWindow::getRelativeScale() const {
+double GLFWGameWindow::getRelativeScale() const {
     return relativeScale;
 }
 
@@ -134,8 +134,8 @@ void GLFWGameWindow::pollEvents() {
         if(requestFullscreen) {
             glfwGetWindowPos(window, &windowedX, &windowedY);
             // convert pixels to window coordinates getRelativeScale() is 2 on macOS retina screens
-            windowedWidth = width / getRelativeScale();
-            windowedHeight = height / getRelativeScale();
+            windowedWidth = (int) floor(width / getRelativeScale());
+            windowedHeight = (int) floor(height / getRelativeScale());
             GLFWmonitor* monitor = glfwGetPrimaryMonitor();
             int nModes = 0;
             auto modes = glfwGetVideoModes(monitor, &nModes);

--- a/src/window_glfw.h
+++ b/src/window_glfw.h
@@ -18,7 +18,7 @@ private:
     int width = -1, height = -1;
     // width and height in window coordinates = pixels / relativeScale
     int windowedWidth = -1, windowedHeight = -1;
-    int relativeScale;
+    double relativeScale;
     bool resized = false;
     bool focused = true;
     bool warnedButtons = false;
@@ -59,7 +59,7 @@ public:
 
     void makeCurrent(bool active) override;
 
-    int getRelativeScale() const;
+    double getRelativeScale() const;
 
     void setRelativeScale();
 


### PR DESCRIPTION
This pull request fixes a bug that is present on the GLFW implementation.

Normally, when you have a HiDPI monitor (e.g. Apple Retina Display or almost any 4K monitor), you need to scale up the monitor's content so that the content isn't too small to view. On X11, usually this only has integer scaling (1x, 2x, 3x), and X11 only measures physical pixels. This leads to an issue where 1x may be too small, but 2x is too big. Wayland uses logical pixels instead. With this in mind, Wayland has something called "Fractional Scaling", so instead of going from 1x to 2x, you can settle for somewhere in between, like 1.25x or 1.5x.

However, the relative scale implementation for GLFW completely fails to take into account fractional scaling. In the current implementation, it truncates any scale to an integer. While that may work in X11, this will not fly by with Wayland. In my case, I have a monitor with 150% scaling, but this implementation truncates that to 100% as 150% is *not an integer* (1.5x).

This leads to some horrible bugs, the most notable one being the application's cursor position being completely misaligned with the OS's cursor. By making relative scale a double instead of an integer, relative scale can now take fractional scaling into account and fix these bugs.