### PR TITLE
Expose active graphics context and host EGL resolver

### DIFF
--- a/include/game_window.h
+++ b/include/game_window.h
@@ -9,6 +9,43 @@ enum class GraphicsApi {
     OPENGL,
     OPENGL_ES2
 };
+
+enum class GraphicsClientApi {
+    UNKNOWN,
+    OPENGL,
+    OPENGL_ES
+};
+
+enum class GraphicsWindowSystem {
+    UNKNOWN,
+    GLFW,
+    SDL3,
+    EGLUT
+};
+
+enum class GraphicsContextProfile {
+    UNKNOWN,
+    CORE,
+    COMPATIBILITY,
+    ES
+};
+
+enum class GraphicsContextCreationApi {
+    UNKNOWN,
+    NATIVE,
+    EGL,
+    OSMESA
+};
+
+struct GraphicsContextInfo {
+    GraphicsWindowSystem windowSystem = GraphicsWindowSystem::UNKNOWN;
+    GraphicsClientApi clientApi = GraphicsClientApi::UNKNOWN;
+    int versionMajor = -1;
+    int versionMinor = -1;
+    int versionRevision = -1;
+    GraphicsContextProfile profile = GraphicsContextProfile::UNKNOWN;
+    GraphicsContextCreationApi creationApi = GraphicsContextCreationApi::UNKNOWN;
+};
 enum class KeyAction {
     PRESS,
     REPEAT,
@@ -93,6 +130,12 @@ public:
     virtual ~GameWindow() {}
 
     virtual void makeCurrent(bool) = 0;
+
+    // Returns properties of the successfully created context. Call this while
+    // the context is current; implementations must not return request hints.
+    virtual GraphicsContextInfo getGraphicsContextInfo() const {
+        return {};
+    }
 
     virtual void setIcon(std::string const& iconPath) = 0;
 

--- a/include/game_window_manager.h
+++ b/include/game_window_manager.h
@@ -25,6 +25,11 @@ public:
 
     virtual ProcAddrFunc getProcAddrFunc() = 0;
 
+    // Returns a resolver for host EGL entry points when the active window
+    // implementation uses EGL. This is separate from the guest GL resolver
+    // exposed to Minecraft and may be unavailable for native contexts.
+    virtual ProcAddrFunc getEglProcAddrFunc() { return nullptr; }
+
     virtual std::shared_ptr<GameWindow>
     createWindow(const std::string& title, int width, int height, GraphicsApi api) = 0;
 

--- a/include/game_window_manager.h
+++ b/include/game_window_manager.h
@@ -19,7 +19,7 @@ public:
     static std::shared_ptr<GameWindowManager> getManager();
 
 
-    using AnyFunc = void* (*)();
+    using AnyFunc = void (*)();
     using ProcAddrFunc = AnyFunc (*)(const char*);
 
 

--- a/src/window_eglut.cpp
+++ b/src/window_eglut.cpp
@@ -76,6 +76,13 @@ void EGLUTWindow::makeCurrent(bool active) {
     eglutMakeCurrent(active ? winId : -1);
 }
 
+GraphicsContextInfo EGLUTWindow::getGraphicsContextInfo() const {
+    GraphicsContextInfo info;
+    info.windowSystem = GraphicsWindowSystem::EGLUT;
+    info.creationApi = GraphicsContextCreationApi::EGL;
+    return info;
+}
+
 void EGLUTWindow::show() {
 #ifdef GAMEWINDOW_X11_LOCK
     std::lock_guard<std::recursive_mutex> lock(x11_sync);

--- a/src/window_eglut.h
+++ b/src/window_eglut.h
@@ -55,6 +55,8 @@ public:
 
     void makeCurrent(bool active) override;
 
+    GraphicsContextInfo getGraphicsContextInfo() const override;
+
     void show() override;
 
     void close() override;

--- a/src/window_glfw.cpp
+++ b/src/window_glfw.cpp
@@ -66,6 +66,57 @@ void GLFWGameWindow::makeCurrent(bool c) {
     glfwMakeContextCurrent(c ? window : nullptr);
 }
 
+GraphicsContextInfo GLFWGameWindow::getGraphicsContextInfo() const {
+    GraphicsContextInfo info;
+    info.windowSystem = GraphicsWindowSystem::GLFW;
+
+    switch(glfwGetWindowAttrib(window, GLFW_CLIENT_API)) {
+    case GLFW_OPENGL_API:
+        info.clientApi = GraphicsClientApi::OPENGL;
+        break;
+    case GLFW_OPENGL_ES_API:
+        info.clientApi = GraphicsClientApi::OPENGL_ES;
+        break;
+    default:
+        break;
+    }
+
+    info.versionMajor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MAJOR);
+    info.versionMinor = glfwGetWindowAttrib(window, GLFW_CONTEXT_VERSION_MINOR);
+    info.versionRevision = glfwGetWindowAttrib(window, GLFW_CONTEXT_REVISION);
+
+    if(info.clientApi == GraphicsClientApi::OPENGL_ES) {
+        info.profile = GraphicsContextProfile::ES;
+    } else {
+        switch(glfwGetWindowAttrib(window, GLFW_OPENGL_PROFILE)) {
+        case GLFW_OPENGL_CORE_PROFILE:
+            info.profile = GraphicsContextProfile::CORE;
+            break;
+        case GLFW_OPENGL_COMPAT_PROFILE:
+            info.profile = GraphicsContextProfile::COMPATIBILITY;
+            break;
+        default:
+            break;
+        }
+    }
+
+    switch(glfwGetWindowAttrib(window, GLFW_CONTEXT_CREATION_API)) {
+    case GLFW_NATIVE_CONTEXT_API:
+        info.creationApi = GraphicsContextCreationApi::NATIVE;
+        break;
+    case GLFW_EGL_CONTEXT_API:
+        info.creationApi = GraphicsContextCreationApi::EGL;
+        break;
+    case GLFW_OSMESA_CONTEXT_API:
+        info.creationApi = GraphicsContextCreationApi::OSMESA;
+        break;
+    default:
+        break;
+    }
+
+    return info;
+}
+
 GLFWGameWindow::~GLFWGameWindow() {
 #ifdef GAMEWINDOW_X11_LOCK
     std::lock_guard<std::recursive_mutex> lock(x11_sync);

--- a/src/window_glfw.h
+++ b/src/window_glfw.h
@@ -59,6 +59,8 @@ public:
 
     void makeCurrent(bool active) override;
 
+    GraphicsContextInfo getGraphicsContextInfo() const override;
+
     double getRelativeScale() const;
 
     void setRelativeScale();

--- a/src/window_manager_eglut.cpp
+++ b/src/window_manager_eglut.cpp
@@ -10,8 +10,13 @@
 #endif
 #include <libgen.h>
 #include <cstring>
+#include <EGL/egl.h>
 
-extern "C" void eglGetProcAddress();
+namespace {
+GameWindowManager::AnyFunc resolveEglProcAddress(const char* name) {
+    return reinterpret_cast<GameWindowManager::AnyFunc>(eglGetProcAddress(name));
+}
+}
 
 EGLUTWindowManager::EGLUTWindowManager() {
     char buf[PATH_MAX];
@@ -22,11 +27,11 @@ EGLUTWindowManager::EGLUTWindowManager() {
 }
 
 GameWindowManager::ProcAddrFunc EGLUTWindowManager::getProcAddrFunc() {
-    return (GameWindowManager::ProcAddrFunc) eglGetProcAddress;
+    return resolveEglProcAddress;
 }
 
 GameWindowManager::ProcAddrFunc EGLUTWindowManager::getEglProcAddrFunc() {
-    return (GameWindowManager::ProcAddrFunc) eglGetProcAddress;
+    return resolveEglProcAddress;
 }
 
 std::shared_ptr<GameWindow> EGLUTWindowManager::createWindow(const std::string& title, int width, int height,

--- a/src/window_manager_eglut.cpp
+++ b/src/window_manager_eglut.cpp
@@ -25,6 +25,10 @@ GameWindowManager::ProcAddrFunc EGLUTWindowManager::getProcAddrFunc() {
     return (GameWindowManager::ProcAddrFunc) eglGetProcAddress;
 }
 
+GameWindowManager::ProcAddrFunc EGLUTWindowManager::getEglProcAddrFunc() {
+    return (GameWindowManager::ProcAddrFunc) eglGetProcAddress;
+}
+
 std::shared_ptr<GameWindow> EGLUTWindowManager::createWindow(const std::string& title, int width, int height,
                                                              GraphicsApi api) {
     return std::shared_ptr<GameWindow>(new EGLUTWindow(title, width, height, api));

--- a/src/window_manager_eglut.h
+++ b/src/window_manager_eglut.h
@@ -9,6 +9,8 @@ public:
 
     ProcAddrFunc getProcAddrFunc() override;
 
+    ProcAddrFunc getEglProcAddrFunc() override;
+
     std::shared_ptr<GameWindow> createWindow(const std::string& title, int width, int height, GraphicsApi api) override;
 
     void addGamepadMappingFile(const std::string& path) override;

--- a/src/window_manager_glfw.cpp
+++ b/src/window_manager_glfw.cpp
@@ -16,6 +16,10 @@ GameWindowManager::ProcAddrFunc GLFWWindowManager::getProcAddrFunc() {
     return (GameWindowManager::ProcAddrFunc) glfwGetProcAddress;
 }
 
+GameWindowManager::ProcAddrFunc GLFWWindowManager::getEglProcAddrFunc() {
+    return (GameWindowManager::ProcAddrFunc) glfwGetProcAddress;
+}
+
 std::shared_ptr<GameWindow> GLFWWindowManager::createWindow(const std::string& title, int width, int height,
                                                              GraphicsApi api) {
     return std::shared_ptr<GameWindow>(new GLFWGameWindow(title, width, height, api));

--- a/src/window_manager_glfw.cpp
+++ b/src/window_manager_glfw.cpp
@@ -3,6 +3,12 @@
 #include "joystick_manager_glfw.h"
 #include <stdexcept>
 
+namespace {
+GameWindowManager::AnyFunc resolveGlfwProcAddress(const char* name) {
+    return reinterpret_cast<GameWindowManager::AnyFunc>(glfwGetProcAddress(name));
+}
+}
+
 GLFWWindowManager::GLFWWindowManager() {
     // To create a default mapping for not mapped Gamepads
     // to avoid subtracting heads from buttons again
@@ -13,11 +19,11 @@ GLFWWindowManager::GLFWWindowManager() {
 }
 
 GameWindowManager::ProcAddrFunc GLFWWindowManager::getProcAddrFunc() {
-    return (GameWindowManager::ProcAddrFunc) glfwGetProcAddress;
+    return resolveGlfwProcAddress;
 }
 
 GameWindowManager::ProcAddrFunc GLFWWindowManager::getEglProcAddrFunc() {
-    return (GameWindowManager::ProcAddrFunc) glfwGetProcAddress;
+    return resolveGlfwProcAddress;
 }
 
 std::shared_ptr<GameWindow> GLFWWindowManager::createWindow(const std::string& title, int width, int height,

--- a/src/window_manager_glfw.h
+++ b/src/window_manager_glfw.h
@@ -9,6 +9,8 @@ public:
 
     ProcAddrFunc getProcAddrFunc() override;
 
+    ProcAddrFunc getEglProcAddrFunc() override;
+
     std::shared_ptr<GameWindow> createWindow(const std::string& title, int width, int height, GraphicsApi api) override;
 
     void addGamepadMappingFile(const std::string& path) override;

--- a/src/window_manager_glfw_fallback_eglut.cpp
+++ b/src/window_manager_glfw_fallback_eglut.cpp
@@ -27,6 +27,10 @@ GameWindowManager::ProcAddrFunc GLFWFallbackEGLUTWindowManager::getProcAddrFunc(
     return manager->getProcAddrFunc();
 }
 
+GameWindowManager::ProcAddrFunc GLFWFallbackEGLUTWindowManager::getEglProcAddrFunc() {
+    return manager->getEglProcAddrFunc();
+}
+
 std::shared_ptr<GameWindow> GLFWFallbackEGLUTWindowManager::createWindow(const std::string& title, int width, int height,
                                                              GraphicsApi api) {
     return manager->createWindow(title, width, height, api);

--- a/src/window_manager_glfw_fallback_eglut.h
+++ b/src/window_manager_glfw_fallback_eglut.h
@@ -9,6 +9,8 @@ public:
 
     ProcAddrFunc getProcAddrFunc() override;
 
+    ProcAddrFunc getEglProcAddrFunc() override;
+
     std::shared_ptr<GameWindow> createWindow(const std::string& title, int width, int height, GraphicsApi api) override;
 
     void addGamepadMappingFile(const std::string& path) override;

--- a/src/window_manager_sdl3.cpp
+++ b/src/window_manager_sdl3.cpp
@@ -5,16 +5,26 @@
 
 #include <SDL3/SDL.h>
 
+namespace {
+GameWindowManager::AnyFunc resolveSdlGlProcAddress(const char* name) {
+    return reinterpret_cast<GameWindowManager::AnyFunc>(SDL_GL_GetProcAddress(name));
+}
+
+GameWindowManager::AnyFunc resolveSdlEglProcAddress(const char* name) {
+    return reinterpret_cast<GameWindowManager::AnyFunc>(SDL_EGL_GetProcAddress(name));
+}
+}
+
 SDL3WindowManager::SDL3WindowManager() {
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMEPAD);
 }
 
 GameWindowManager::ProcAddrFunc SDL3WindowManager::getProcAddrFunc() {
-    return (GameWindowManager::ProcAddrFunc) SDL_GL_GetProcAddress;
+    return resolveSdlGlProcAddress;
 }
 
 GameWindowManager::ProcAddrFunc SDL3WindowManager::getEglProcAddrFunc() {
-    return (GameWindowManager::ProcAddrFunc) SDL_EGL_GetProcAddress;
+    return resolveSdlEglProcAddress;
 }
 
 std::shared_ptr<GameWindow> SDL3WindowManager::createWindow(const std::string& title, int width, int height,

--- a/src/window_manager_sdl3.cpp
+++ b/src/window_manager_sdl3.cpp
@@ -13,6 +13,10 @@ GameWindowManager::ProcAddrFunc SDL3WindowManager::getProcAddrFunc() {
     return (GameWindowManager::ProcAddrFunc) SDL_GL_GetProcAddress;
 }
 
+GameWindowManager::ProcAddrFunc SDL3WindowManager::getEglProcAddrFunc() {
+    return (GameWindowManager::ProcAddrFunc) SDL_EGL_GetProcAddress;
+}
+
 std::shared_ptr<GameWindow> SDL3WindowManager::createWindow(const std::string& title, int width, int height,
                                                              GraphicsApi api) {
     return std::shared_ptr<GameWindow>(new SDL3GameWindow(title, width, height, api));

--- a/src/window_manager_sdl3.h
+++ b/src/window_manager_sdl3.h
@@ -9,6 +9,8 @@ public:
 
     ProcAddrFunc getProcAddrFunc() override;
 
+    ProcAddrFunc getEglProcAddrFunc() override;
+
     std::shared_ptr<GameWindow> createWindow(const std::string& title, int width, int height, GraphicsApi api) override;
 
     void addGamepadMappingFile(const std::string& path) override;

--- a/src/window_sdl3.cpp
+++ b/src/window_sdl3.cpp
@@ -63,6 +63,39 @@ void SDL3GameWindow::makeCurrent(bool c) {
     SDL_GL_MakeCurrent(window, c ? context : nullptr);
 }
 
+GraphicsContextInfo SDL3GameWindow::getGraphicsContextInfo() const {
+    GraphicsContextInfo info;
+    info.windowSystem = GraphicsWindowSystem::SDL3;
+    int value = 0;
+
+    if(SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &value)) {
+        info.versionMajor = value;
+    }
+    if(SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &value)) {
+        info.versionMinor = value;
+    }
+    if(SDL_GL_GetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, &value)) {
+        switch(value) {
+        case SDL_GL_CONTEXT_PROFILE_ES:
+            info.clientApi = GraphicsClientApi::OPENGL_ES;
+            info.profile = GraphicsContextProfile::ES;
+            break;
+        case SDL_GL_CONTEXT_PROFILE_CORE:
+            info.clientApi = GraphicsClientApi::OPENGL;
+            info.profile = GraphicsContextProfile::CORE;
+            break;
+        case SDL_GL_CONTEXT_PROFILE_COMPATIBILITY:
+            info.clientApi = GraphicsClientApi::OPENGL;
+            info.profile = GraphicsContextProfile::COMPATIBILITY;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return info;
+}
+
 SDL3GameWindow::~SDL3GameWindow() {
     if(window) {
         SDL_DestroyWindow(window);

--- a/src/window_sdl3.h
+++ b/src/window_sdl3.h
@@ -44,6 +44,8 @@ public:
 
     void makeCurrent(bool active) override;
 
+    GraphicsContextInfo getGraphicsContextInfo() const override;
+
     int getRelativeScale() const;
 
     void setRelativeScale();


### PR DESCRIPTION
## What changed

- add a normalized `GraphicsContextInfo` contract
- report the actual GLFW, SDL3, or EGLUT implementation
- expose the created client API, version, profile, and creation API where the backend can query them
- expose each active backend's host EGL procedure resolver
- preserve exact function-pointer types across the resolver boundary
- delegate both capabilities through the fallback window manager

## Why

MCPELauncher previously retained only the requested graphics API. That is not authoritative because GLFW can retry an OpenGL ES 3 request as ES 2, and the GLFW/EGLUT fallback can select a different implementation. The client also needs to query the host ANGLE/EGL display separately from launcher-owned fake EGL exports.

This provides upstream-friendly diagnostics while the context is current, without changing rendering behavior.

## Validation

- built as part of the client-only arm64 Debug target on macOS
- packaged GLFW/EGL smoke reported the actual OpenGL ES 3.1 context
- the dedicated resolver returned the host EGL identity used by ANGLE
- final client report separately captured fake guest EGL and host EGL identities
- SDL3, EGLUT, GLFW, and fallback implementations were reviewed for lifecycle and ABI consistency
